### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/apps/team-generator/src/teamler.js
+++ b/apps/team-generator/src/teamler.js
@@ -19,7 +19,9 @@ export class Teamler {
      * Get name escaped for Markdown
      */
     getNameForMarkdown() {
-        return this.name.replace(/_/g, '\\_');
+        return this.name
+            .replace(/\\/g, '\\\\')
+            .replace(/_/g, '\\_');
     }
 
     /**


### PR DESCRIPTION
Potential fix for [https://github.com/TimoliaDE/HowTo/security/code-scanning/6](https://github.com/TimoliaDE/HowTo/security/code-scanning/6)

To fix this safely, escape backslashes **before** escaping underscores. This preserves current functionality (underscores are still escaped) while closing the gap identified by CodeQL.

Best single change in `apps/team-generator/src/teamler.js`:
- In `getNameForMarkdown()` (around line 22), replace the one-step underscore escape with a two-step chain:
  1. `replace(/\\/g, '\\\\')` to escape all literal backslashes.
  2. `replace(/_/g, '\\_')` to escape all underscores.

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
